### PR TITLE
chore: pin GitHub Actions to full SHA commits

### DIFF
--- a/.github/workflows/trivy_checkov_wizcli.yml
+++ b/.github/workflows/trivy_checkov_wizcli.yml
@@ -17,7 +17,7 @@ jobs:
       tf_dirs: ${{ steps.set_tf_dirs.outputs.tf_dirs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get Terraform directories
         id: set_tf_dirs
@@ -35,7 +35,7 @@ jobs:
         tf-dir: ${{ fromJson(needs.get-tf-directories.outputs.tf_dirs) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install checkov
         run: |
@@ -43,7 +43,7 @@ jobs:
           checkov --version
 
       - name: 🔍 Run Trivy scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         continue-on-error: true
         with:
           scan-type: fs


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` from `v4` tag to full SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- Pin `aquasecurity/trivy-action` from `0.28.0` tag to full SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- Improves supply chain security by preventing tag hijacking attacks