### PR TITLE
fix: add explicit permissions to trivy_checkov_wizcli workflow

### DIFF
--- a/.github/workflows/trivy_checkov_wizcli.yml
+++ b/.github/workflows/trivy_checkov_wizcli.yml
@@ -6,6 +6,9 @@ on:
       - synchronize
       - opened
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash -euxo pipefail {0}


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `trivy_checkov_wizcli.yml`
- Prevents inheriting overly broad default permissions, following GitHub Actions
  security best practices per
  [Datadog IaC Security recommendations](https://www.datadoghq.com/blog/github-actions-iac-security/)